### PR TITLE
build: fix the libdl linking issue

### DIFF
--- a/cmake/iotjs.cmake
+++ b/cmake/iotjs.cmake
@@ -395,6 +395,7 @@ set_target_properties(${TARGET_LIB_IOTJS} PROPERTIES
 )
 target_include_directories(${TARGET_LIB_IOTJS} PRIVATE ${IOTJS_INCLUDE_DIRS})
 target_link_libraries(${TARGET_LIB_IOTJS}
+  ${CMAKE_DL_LIBS}
   ${JERRY_LIBS}
   ${TUV_LIBS}
   libhttp-parser


### PR DESCRIPTION
Add `CMAKE_DL_LIBS` to `target_link_libraries()` to find the libdl.