### PR TITLE
 crypto: add Hash functions

### DIFF
--- a/docs/api/IoT.js-API-Crypto.md
+++ b/docs/api/IoT.js-API-Crypto.md
@@ -120,6 +120,18 @@ input.on('readable', () => {
 });
 ```
 
+### crypto.getHashes()
+
+Returns an array of the names of the supported hash algorithms,
+such as `RSA-SHA256`.
+
+Example:
+
+```js
+const hashes = crypto.getHashes();
+console.log(hashes);
+```
+
 ### crypto.randomBytes(size[, callback])
 
 * size {Number}

--- a/docs/api/IoT.js-API-Crypto.md
+++ b/docs/api/IoT.js-API-Crypto.md
@@ -1,15 +1,126 @@
-# DBus
+# Crypto
 
-DBus is the module for IPC.
+The `crypto` module provides cryptographic functionality that includes a set of
+wrappers for OpenSSL's hash, HMAC, cipher, decipher, sign, and verify functions.
 
-**Example**
+Use `require('crypto')` to access this module.
+
+## Class: Hash
+
+The `Hash` class is a utility for creating hash digests of data. It can be
+used in one of two ways:
+
+- As a [stream][] that is both readable and writable, where data is written
+  to produce a computed hash digest on the readable side, or
+- Using the [`hash.update()`][] and [`hash.digest()`][] methods to produce the
+  computed hash.
+
+The [`crypto.createHash()`][] method is used to create `Hash` instances. `Hash`
+objects are not to be created directly using the `new` keyword.
+
+Example: Using `Hash` objects as streams:
 
 ```js
-var crypto = require('crypto');
-console.log(crypto.randomBytes(32).toString('hex'));
+const crypto = require('crypto');
+const hash = crypto.createHash('sha256');
+
+hash.on('readable', () => {
+  const data = hash.read();
+  if (data) {
+    console.log(data.toString('hex'));
+    // Prints:
+    //   6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50
+  }
+});
+
+hash.write('some data to hash');
+hash.end();
 ```
 
-## randomBytes(size[, callback])
+Example: Using `Hash` and piped streams:
+
+```js
+const crypto = require('crypto');
+const fs = require('fs');
+const hash = crypto.createHash('sha256');
+
+const input = fs.createReadStream('test.js');
+input.pipe(hash).pipe(process.stdout);
+```
+
+Example: Using the [`hash.update()`][] and [`hash.digest()`][] methods:
+
+```js
+const crypto = require('crypto');
+const hash = crypto.createHash('sha256');
+
+hash.update('some data to hash');
+console.log(hash.digest('hex'));
+// Prints:
+//   6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50
+```
+
+### hash.digest([encoding])
+
+- `encoding` {string}
+
+Calculates the digest of all of the data passed to be hashed (using the
+[`hash.update()`][] method). The `encoding` can be `'hex'`, `'latin1'` or
+`'base64'`. If `encoding` is provided a string will be returned; otherwise
+a [`Buffer`][] is returned.
+
+The `Hash` object can not be used again after `hash.digest()` method has been
+called. Multiple calls will cause an error to be thrown.
+
+### hash.update(data[, inputEncoding])
+
+- `data` {string | Buffer | TypedArray | DataView}
+- `inputEncoding` {string}
+
+Updates the hash content with the given `data`, the encoding of which
+is given in `inputEncoding` and can be `'utf8'`, `'ascii'` or
+`'latin1'`. If `encoding` is not provided, and the `data` is a string, an
+encoding of `'utf8'` is enforced. If `data` is a [`Buffer`][], `TypedArray`, or
+`DataView`, then `inputEncoding` is ignored.
+
+This can be called many times with new data as it is streamed.
+
+## `crypto` module methods and properties
+
+### crypto.createHash(algorithm[, options])
+
+- `algorithm` {string}
+- `options` {Object} [`stream.transform` options][]
+
+Creates and returns a `Hash` object that can be used to generate hash digests
+using the given `algorithm`. Optional `options` argument controls stream
+behavior.
+
+The `algorithm` is dependent on the available algorithms supported by the
+version of OpenSSL on the platform. Examples are `'sha256'`, `'sha512'`, etc.
+On recent releases of OpenSSL, `openssl list-message-digest-algorithms` will
+display the available digest algorithms.
+
+Example: generating the sha256 sum of a file
+
+```js
+const filename = process.argv[2];
+const crypto = require('crypto');
+const fs = require('fs');
+const hash = crypto.createHash('sha256');
+
+const input = fs.createReadStream(filename);
+input.on('readable', () => {
+  const data = input.read();
+  if (data)
+    hash.update(data);
+  else {
+    console.log(`${hash.digest('hex')} ${filename}`);
+  }
+});
+```
+
+### crypto.randomBytes(size[, callback])
 
 * size {Number}
 * callback {Function}

--- a/src/js/crypto.js
+++ b/src/js/crypto.js
@@ -1,5 +1,51 @@
 // var _randomBytes = native.randomBytes;
 var _randomBytesSync = native.randomBytesSync;
+var _Hash = require('crypto_hash').Hash;
+
+function Hash(algorithm) {
+  if (!Hash._hashes[algorithm]) {
+    throw new Error('Unknown hash algorithm ' + algorithm);
+  }
+  this._handle = new _Hash(Hash._hashes[algorithm]);
+}
+
+Hash.prototype.update = function(buf, inputEncoding) {
+  if (Buffer.isBuffer(buf) && inputEncoding) {
+    buf = buf.toString(inputEncoding);
+  }
+  this._handle.update(buf);
+  return this;
+};
+
+Hash.prototype.digest = function(encoding) {
+  var buf = this._handle.digest();
+  if (typeof encoding === 'string') {
+    return buf.toString(encoding);
+  } else {
+    return buf;
+  }
+};
+
+Hash._hashes = {
+  'none': 0,
+  'md2': 1,
+  'md4': 2,
+  'md5': 3,
+  'sha1': 4,
+  'sha224': 5,
+  'sha256': 6,
+  'sha384': 7,
+  'sha512': 8,
+  'ripemd160': 9
+};
+
+exports.createHash = function(algorithm) {
+  return new Hash(algorithm);
+};
+
+exports.getHashes = function() {
+  return Object.keys(Hash._hashes);
+};
 
 exports.randomBytes = function(size, callback) {
   var bytes = _randomBytesSync(size);

--- a/src/modules.json
+++ b/src/modules.json
@@ -153,7 +153,12 @@
     "crypto": {
       "js_file": "js/crypto.js",
       "native_files": ["modules/iotjs_module_crypto.c"],
-      "init": "InitCrypto"
+      "init": "InitCrypto",
+      "require": ["crypto_hash"]
+    },
+    "crypto_hash": {
+      "native_files": ["modules/iotjs_module_crypto_hash.c"],
+      "init": "InitCryptoHash"
     },
     "dbus": {
       "native_files": ["modules/iotjs_module_dbus.c"],

--- a/src/modules/iotjs_module_crypto.c
+++ b/src/modules/iotjs_module_crypto.c
@@ -1,4 +1,5 @@
 #include "iotjs_def.h"
+#include "iotjs_objectwrap.h"
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
 
@@ -8,6 +9,7 @@ mbedtls_entropy_context entropy;
 mbedtls_ctr_drbg_context drgb_ctx;
 
 JS_FUNCTION(RandomBytes) {
+  // TODO
   return jerry_create_null();
 }
 
@@ -24,7 +26,6 @@ JS_FUNCTION(RandomBytesSync) {
   }
   return res;
 }
-
 jerry_value_t InitCrypto() {
   mbedtls_entropy_init(&entropy);
   mbedtls_ctr_drbg_init(&drgb_ctx);
@@ -37,6 +38,5 @@ jerry_value_t InitCrypto() {
   jerry_value_t crypto = jerry_create_object();
   iotjs_jval_set_method(crypto, "randomBytes", RandomBytes);
   iotjs_jval_set_method(crypto, "randomBytesSync", RandomBytesSync);
-
   return crypto;
 }


### PR DESCRIPTION
Adds the following functions:

- `crypto.getHashes()`
- `crypto.createHash()`

and the `Hash` class which provides:

- `.update(buffer, inputEncoding)`
- `.digest(encoding)`

This also tries to complete the list on #2.