### PR TITLE
stream: add pipe to dest and returns dest

### DIFF
--- a/src/js/stream_readable.js
+++ b/src/js/stream_readable.js
@@ -155,6 +155,8 @@ Readable.prototype.pipe = function(dest) {
   src.on('end', function() {
     dest.end();
   });
+  dest.emit('pipe', src);
+  return dest;
 };
 
 


### PR DESCRIPTION
The `pipe` should returns the dest for the following usage:

```js
a.pipe(b).pipe(c);
```