### PR TITLE
config: increase the default heap memory to 4096

### DIFF
--- a/build.config
+++ b/build.config
@@ -10,7 +10,7 @@
   "external-lib": [],
   "jerry-cmake-param": [],
   "jerry-compile-flag": [],
-  "jerry-heaplimit": 256,
+  "jerry-heaplimit": 4096,
   "jerry-link-flag": [],
   "jerry-lto": false,
   "jerry-memstat": false,


### PR DESCRIPTION
Increasing the heap memory to 16x might be more proper for Node.js-compatible runtime :)